### PR TITLE
[Serialization] Throw catchable exception if class does not exist for deserialization

### DIFF
--- a/src/Serialization/Exception/SerializedClassDoesNotExist.php
+++ b/src/Serialization/Exception/SerializedClassDoesNotExist.php
@@ -1,0 +1,13 @@
+<?php namespace SmoothPhp\Serialization\Exception;
+
+use Exception;
+
+/**
+ * Class SerializedClassDoesNotExist
+ * @package SmoothPhp\Serialization\Exception
+ * @author jrdn hannah <jrdn@jrdnhannah.co.uk>
+ */
+final class SerializedClassDoesNotExist extends Exception
+{
+
+}

--- a/src/Serialization/ObjectSelfSerializer.php
+++ b/src/Serialization/ObjectSelfSerializer.php
@@ -4,6 +4,7 @@ namespace SmoothPhp\Serialization;
 use SmoothPhp\Contracts\Serialization\Serializer;
 use SmoothPhp\Contracts\Serialization\Serializable;
 use SmoothPhp\Serialization\Exception\SerializationException;
+use SmoothPhp\Serialization\Exception\SerializedClassDoesNotExist;
 
 /**
  * Class ObjectSelfSerializer
@@ -33,14 +34,18 @@ final class ObjectSelfSerializer implements Serializer
      */
     public function deserialize(array $serializedObject)
     {
-        if (! in_array(Serializable::class, class_implements($serializedObject['class']))) {
+        if (! class_exists($class = $serializedObject['class'])) {
+            throw new SerializedClassDoesNotExist("Class does not exist: [{$class}]");
+        }
+
+        if (! in_array(Serializable::class, class_implements($class))) {
             throw new SerializationException(
                 sprintf(
                     'Class \'%s\' does not implement Serializable',
-                    $serializedObject['class']
+                    $class
                 )
             );
         }
-        return $serializedObject['class']::deserialize($serializedObject['payload']);
+        return $class::deserialize($serializedObject['payload']);
     }
 }

--- a/tests/Serialization/ObjectSelfSerializerTest.php
+++ b/tests/Serialization/ObjectSelfSerializerTest.php
@@ -62,6 +62,18 @@ final class ObjectSelfSerializerTest extends TestCase
         $this->assertInstanceOf(SerializableObject::class, $object);
         $this->assertEquals('foo', $object->getFoo());
     }
+
+    /**
+     * @test
+     * @expectedException SmoothPhp\Serialization\Exception\SerializedClassDoesNotExist
+     */
+    public function it_should_throw_exception_on_non_existant_class()
+    {
+        $serializer = new ObjectSelfSerializer;
+        $data       = ['class' => 'Foo\Bar\Baz', 'payload' => ['foo' => 'bar']];
+
+        $object     = $serializer->deserialize($data);
+    }
 }
 
 final class SerializableObject implements Serializable


### PR DESCRIPTION
This can then be caught by packages which implement this serializer.
