### PR TITLE
[Event Dispatcher] Remove projection interface

### DIFF
--- a/src/Contracts/EventDispatcher/Projection.php
+++ b/src/Contracts/EventDispatcher/Projection.php
@@ -3,6 +3,7 @@ namespace SmoothPhp\Contracts\EventDispatcher;
 
 /**
  * Interface Projection
+ * @deprecated No Longer Required with projection service providers
  * @package SmoothPhp\Contracts\EventDispatcher
  * @author Simon Bennett <simon@bennett.im>
  */

--- a/src/EventDispatcher/ProjectEnabledDispatcher.php
+++ b/src/EventDispatcher/ProjectEnabledDispatcher.php
@@ -2,7 +2,6 @@
 namespace SmoothPhp\EventDispatcher;
 
 use SmoothPhp\Contracts\EventDispatcher\EventDispatcher;
-use SmoothPhp\Contracts\EventDispatcher\Projection;
 use SmoothPhp\Contracts\EventDispatcher\Subscriber;
 
 /**
@@ -33,9 +32,7 @@ final class ProjectEnabledDispatcher implements EventDispatcher
             return;
         }
         foreach ($this->getListenersInOrder($eventName) as $listener) {
-            if ($this->listenerCanRun($runProjectionsOnly, $listener)) {
-                call_user_func_array($listener, $arguments);
-            }
+            call_user_func_array($listener, $arguments);
         }
     }
 
@@ -70,16 +67,6 @@ final class ProjectEnabledDispatcher implements EventDispatcher
                 }
             }
         }
-    }
-
-    /**
-     * @param $runProjectionsOnly
-     * @param $listener
-     * @return bool
-     */
-    protected function listenerCanRun($runProjectionsOnly, $listener)
-    {
-        return !$runProjectionsOnly || (is_array($listener) && $listener[0] instanceof Projection);
     }
 
     /**

--- a/tests/EventDispatcher/ProjectEnabledDispatcherTest.php
+++ b/tests/EventDispatcher/ProjectEnabledDispatcherTest.php
@@ -94,8 +94,7 @@ final class ProjectEnabledDispatcherTest extends \PHPUnit_Framework_TestCase
         $dispatcher->dispatch('test', [], true);
 
         $this->assertEquals(1, $projectionListener->runCount);
-        $this->assertEquals(0, $noneProjectionListener->runCount);
-
+        $this->assertEquals(1, $noneProjectionListener->runCount);
 
     }
 


### PR DESCRIPTION
As we can now configure the application to decide which projections to run during a rebuild there is no longer a need for the system to magically (using interface) know if a event subscriber is projection only.