### PR TITLE
Fix: Make tests in EventSourcedRepositoryTest pass

### DIFF
--- a/tests/EventSourcing/EventSourcedRepositoryTest.php
+++ b/tests/EventSourcing/EventSourcedRepositoryTest.php
@@ -136,12 +136,14 @@ class MockStore implements EventStore
      * @param int $take
      * @return \Generator
      */
-    public function getEventsByType($eventTypes, $skip, $take) : \Generator
+    public function getEventsByType($eventTypes, $take) : \Generator
     {
     }
 
     /**
      * @param string $streamId
+     *
+     * @throws \Exception
      */
     public function deleteStream(string $streamId) : void
     {
@@ -161,7 +163,9 @@ class MockEventBus implements EventBus
 
     /**
      * @param $eventListener
+     *
      * @return mixed
+     * @throws \Exception
      */
     public function subscribe(EventListener $eventListener)
     {


### PR DESCRIPTION
Fix for
Fatal error:
Declaration of
SmoothPhp\Test\AggregateRoot\MockStore::getEventsByType($eventTypes, $skip, $take): Generator 
must be compatible with
SmoothPhp\Contracts\EventStore\EventStore::getEventsByType(array $eventTypes, int $take): Generator 
in
SmoothPhp/CQRS-ES-Framework/tests/EventSourcing/EventSourcedRepositoryTest.php on line 139