### PR TITLE
Dlaytonjames fix test event sourced repository test

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,7 +22,7 @@
     <logging>
         <log type="tap" target="build/report.tap"/>
         <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
+        <log type="coverage-html" target="build/coverage"/>
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>

--- a/tests/EventSourcing/EventSourcedRepositoryTest.php
+++ b/tests/EventSourcing/EventSourcedRepositoryTest.php
@@ -136,12 +136,14 @@ class MockStore implements EventStore
      * @param int $take
      * @return \Generator
      */
-    public function getEventsByType($eventTypes, $skip, $take) : \Generator
+    public function getEventsByType($eventTypes, $take) : \Generator
     {
     }
 
     /**
      * @param string $streamId
+     *
+     * @throws \Exception
      */
     public function deleteStream(string $streamId) : void
     {
@@ -161,7 +163,9 @@ class MockEventBus implements EventBus
 
     /**
      * @param $eventListener
+     *
      * @return mixed
+     * @throws \Exception
      */
     public function subscribe(EventListener $eventListener)
     {


### PR DESCRIPTION
Fix for
Fatal error:
Declaration of
SmoothPhp\Test\AggregateRoot\MockStore::getEventsByType($eventTypes, $skip, $take): Generator
must be compatible with
SmoothPhp\Contracts\EventStore\EventStore::getEventsByType(array $eventTypes, int $take): Generator
in
SmoothPhp/CQRS-ES-Framework/tests/EventSourcing/EventSourcedRepositoryTest.php on line 139