### PR TITLE
Dlaytonjames update base requirements to allow nesbot carbon v2

### DIFF
--- a/src/Contracts/EventStore/EventStore.php
+++ b/src/Contracts/EventStore/EventStore.php
@@ -18,29 +18,27 @@ interface EventStore
      * @return DomainEventStream
      * @throws EventStreamNotFound
      */
-    public function load($id) : DomainEventStream;
+    public function load(string $id) : DomainEventStream;
 
     /**
      * @param mixed $id
      * @param DomainEventStream $eventStream
-     * @param bool $ignorePlayhead
      * @return void
      */
-    public function append($id, DomainEventStream $eventStream, bool $ignorePlayhead = false) : void;
+    public function append(string $id, DomainEventStream $eventStream) : void;
 
     /**
      * @param string[] $eventTypes
      * @return int
      */
-    public function getEventCountByTypes($eventTypes) : int;
+    public function getEventCountByTypes(array $eventTypes) : int;
 
     /**
      * @param string[] $eventTypes
-     * @param int $skip
      * @param int $take
      * @return \Generator
      */
-    public function getEventsByType($eventTypes, $skip, $take) : \Generator;
+    public function getEventsByType(array $eventTypes, int $take) : \Generator;
 
     /**
      * @param string $streamId

--- a/src/Contracts/Projections/ProjectionServiceProvider.php
+++ b/src/Contracts/Projections/ProjectionServiceProvider.php
@@ -11,12 +11,12 @@ interface ProjectionServiceProvider
     /**
      * @return string|null
      */
-    public function up() : ?string;
+    public function up();
 
     /**
      * @return string|null
      */
-    public function down() : ?string;
+    public function down();
 
     /**
      * @return string[]


### PR DESCRIPTION
Update composer base requirements to allow the use of Nesbot/Carbon 2.0
Update base PHP version from 7.0.0 to 7.1.8
Update Nesbot/Carbon from 1.19 to 2.0+
Update phpunit requirement to match Nesbot/Carbon

All tests pass